### PR TITLE
clean up remaining events on thread exit.

### DIFF
--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.6a1"
+VERSION = "0.1.6a2"

--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.5"
+VERSION = "0.1.6a0"

--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.6a2"
+VERSION = "0.1.6a3"

--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.6a3"
+VERSION = "0.1.6"

--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.6a0"
+VERSION = "0.1.6a1"

--- a/m2mclient/client.py
+++ b/m2mclient/client.py
@@ -91,7 +91,7 @@ class CommandResult(object):
     def __repr__(self):
         return "CommandResult({!r})".format(self.name)
 
-    def set_result(self, result):
+    def set(self, result):
         """Set the result from another thread."""
         log.debug('command result %r', result)
         self._result = result
@@ -169,7 +169,7 @@ class M2MClient:
 
             while self.command_events:
                 command_id, result = self.command_events.popitem()
-                result.set_result(None)
+                result.set(None)
 
     def get_identity(self, timeout=10):
         """
@@ -284,9 +284,9 @@ class M2MClient:
             command_result = self.command_events.pop(command_id)
         except KeyError:
             log.error('received a response to an unknown event')
-            command.set_result(None)
+            command_result.set(None)
         else:
-            command.set_result(result)
+            command_result.set(result)
 
     @expose(PacketType.set_identity)
     def handle_set_identitiy(self, identity):

--- a/m2mclient/client.py
+++ b/m2mclient/client.py
@@ -45,8 +45,8 @@ class WebSocketThread(Thread):
                         self.error = event.reason
                 elif event.name == 'ready':
                     self.running = True
-                    self.ready_event.set()
                     self.on_startup()
+                    self.ready_event.set()
                 elif event.name == 'binary':
                     self.on_binary(event.data)
         finally:
@@ -56,6 +56,7 @@ class WebSocketThread(Thread):
     def on_binary(self, data):
         """Called with a binary message."""
         if not self.client:
+            log.warning('ws message %r ignored', data)
             return
         try:
             packet = M2MPacket.from_bytes(data)

--- a/m2mclient/client.py
+++ b/m2mclient/client.py
@@ -136,8 +136,8 @@ class M2MClient:
         self.command_id = 0
         self.command_events = {}
         self.ws = None
-        self.create_ws()
         self.identity_event = Event()
+        self.create_ws()
 
     def create_ws(self):
         self.ws = WebSocketThread(


### PR DESCRIPTION
### What this PR solves
- Fixes a race condition which sometimes caused the login to be sent after the command packet.
- Ensures all command response objects are set if there is an error conecting.

### How it is done
- Generally by moving things around so they are done in the right order.

### What to look out for
- Bugs

### Screenshots (if appropriate)
-
### Review
- [x] Ready for review
