### PR TITLE
close rather than send request_leave

### DIFF
--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.7a"
+VERSION = "0.1.7"

--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.6"
+VERSION = "0.1.7a"

--- a/m2mclient/client.py
+++ b/m2mclient/client.py
@@ -158,12 +158,8 @@ class M2MClient:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            # Ask politely to leave
+            # Close the websocket
             self.close()
-            # Wait until we're done
-            if not self.ws.join(1):
-                # Force a close if we didn't complete
-                self.ws.close()
         finally:
             self.ws = None
             self.dispatcher.close()
@@ -193,7 +189,7 @@ class M2MClient:
         """A graceful close."""
         # If everything is working, the server will kick us in a few
         # milliseconds.
-        self.send('request_leave')
+        self.ws.close()
 
     def send(self, packet_type, *args, **kwargs):
         """Send a packet."""


### PR DESCRIPTION
# WIP

### What this PR solves
- Handle the case where server quits before we want it to, which can happen when Redis is down.

### How it is done
- Do a websocket close rather than send a request_leave packet.

### What to look out for
- Bugs

### Screenshots (if appropriate)
-

### Review
- [x] Ready for review
