### PR TITLE
use latest lomond, add user agent

### DIFF
--- a/m2mclient/_version.py
+++ b/m2mclient/_version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = "0.1.8"
+VERSION = "0.1.9"

--- a/m2mclient/client.py
+++ b/m2mclient/client.py
@@ -1,9 +1,11 @@
 import weakref
 import logging
+import socket
 from threading import Event
 from threading import Thread
 
 from lomond import WebSocket
+from lomond.constants import USER_AGENT as LOMOND_USER_AGENT
 
 from .dispatcher import Dispatcher
 from .dispatcher import PacketFormatError
@@ -20,9 +22,14 @@ log = logging.getLogger('m2m')
 class WebSocketThread(Thread):
     """Websocket thread."""
 
+    AGENT = "{} {}".format(
+        socket.gethostname(),
+        LOMOND_USER_AGENT
+    )
+
     def __init__(self, url, client, on_startup=None):
         super().__init__()
-        self.ws = WebSocket(url)
+        self.ws = WebSocket(url, agent=self.AGENT)
         self._client = weakref.ref(client)
         self.on_startup = on_startup or (lambda: None)
         self.running = False

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     exclude_package_data={'': ['_*', 'docs/*']},
     classifiers=classifiers,
     install_requires=[
-        'lomond==0.1.7a0',
+        'lomond==0.1.14',
         'wsaccel==0.6.2'
     ]
 )


### PR DESCRIPTION
### What this PR solves
- Updates Lomond to release that doesn't use select
- Sets a user agent so we can see api traffic in router logs 

### How it is done
-
### What to look out for
-
### Screenshots (if appropriate)
-
### Review
- [x] Ready for review
